### PR TITLE
Redirect dtan4.dev and dtan4-dev.netlify.com to dtan4.net

### DIFF
--- a/html/_redirects
+++ b/html/_redirects
@@ -2,3 +2,6 @@ https://dtan4-net.netlify.com/* https://dtan4.net/:splat 301!
 
 https://dtan4.com/* https://dtan4.net/:splat 301!
 https://dtan4-com.netlify.com/* https://dtan4.com/:splat 301!
+
+https://dtan4.dev/* https://dtan4.net/:splat 301!
+https://dtan4-dev.netlify.com/* https://dtan4.dev/:splat 301!


### PR DESCRIPTION
## WHAT

Redirect https://dtan4.dev and https://dtan4-dev.netlify.com to https://dtan4.net

## WHY

I'd like to integrate all requests to my own domain to https://dtan4.net

## REF

- [Add redirect rules of dtan4-*.netlify.com to dtan4.* by dtan4 · Pull Request #2 · dtan4/website](https://github.com/dtan4/website/pull/2)